### PR TITLE
Script update to skip prompts while installing

### DIFF
--- a/gpu/install_gpu_drivers.sh
+++ b/gpu/install_gpu_drivers.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 function install_gpu() {
-    curl -O http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-repo-ubuntu1804_10.0.130-1_amd64.deb
+    curl -O https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-repo-ubuntu1804_10.0.130-1_amd64.deb
     sudo dpkg -i cuda-repo-ubuntu1804_10.0.130-1_amd64.deb
-    sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+    sudo apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
 
         sudo apt update
         sudo apt-get -y install cuda

--- a/gpu/install_gpu_drivers.sh
+++ b/gpu/install_gpu_drivers.sh
@@ -6,7 +6,7 @@ function install_gpu() {
     sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
 
         sudo apt update
-        sudo apt install cuda
+        sudo apt-get -y install cuda
 
         echo "################################# Validate NVIDIA-SMI #####################################"
         nvidia-smi


### PR DESCRIPTION
The earlier command use to ask prompt about memory space consumption. Made changes So that prompts will not be asked to interrupt the install.