### PR TITLE
AIFBR-4473: Domain Based Access & App Manager DB Creation

### DIFF
--- a/database/createDatabases.ps1
+++ b/database/createDatabases.ps1
@@ -22,6 +22,9 @@
 
     If you wish to generate DB Names with suffixes, this is just for testing purpose:
     ./createDatabases.ps1 -sqlinstance "DESKTOP-LOUPTI1\SQLEXPRESS" -windowsAuthentication "N" -dbuser "aifadmin" -dbpass "admin@123" -suffix "_tbd"
+
+    If user supplied password has to be used instead of script autogenerating the same:
+    ./createDatabases.ps1 -sqlinstance "DESKTOP-LOUPTI1\SQLEXPRESS" -windowsAuthentication "N" -dbuser "aifadmin" -dbpass "admin@123"
 #>
 
 Param (

--- a/database/createDatabases.ps1
+++ b/database/createDatabases.ps1
@@ -21,7 +21,7 @@
     ./createDatabases.ps1 -sqlinstance "DESKTOP-LOUPTI1\SQLEXPRESS" -windowsAuthentication "N" -dbuser "aifadmin"
 
     If you wish to generate DB Names with suffixes, this is just for testing purpose:
-    ./createDatabases.ps1 -sqlinstance "DESKTOP-LOUPTI1\SQLEXPRESS" -windowsAuthentication "N" -dbuser "aifadmin" -suffix "_tbd"
+    ./createDatabases.ps1 -sqlinstance "DESKTOP-LOUPTI1\SQLEXPRESS" -windowsAuthentication "N" -dbuser "aifadmin" -dbpass "admin@123" -suffix "_tbd"
 #>
 
 Param (
@@ -31,6 +31,8 @@ Param (
    [string] $windowsAuthentication,
    [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName)]
    [string] $dbuser,
+   [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName)]
+   [string] $dbpass,
    [Parameter(Mandatory = $false, ValueFromPipelineByPropertyName)]
    [string] $suffix
 )
@@ -135,7 +137,13 @@ ALTER ROLE [db_owner] ADD MEMBER $dbuser
 GO
 "
 
-$unsecurepassword = generatePassword
+#If user supplied the pass use it, otherwise auto generate the pass
+if($dbpass.Length -gt 0){
+    $unsecurepassword = $dbpass.ToString()
+} else {
+    $unsecurepassword = generatePassword
+}
+
 $sqlcommand = $sqlcommand.Replace("{{pwd}}",$unsecurepassword)
 
 #Create Login
@@ -164,6 +172,7 @@ executeQuery master $createDatabaseQuery.Replace("{{DB}}", "ai_helper$suffix")
 executeQuery master $createDatabaseQuery.Replace("{{DB}}", "ai_deployer$suffix")
 executeQuery master $createDatabaseQuery.Replace("{{DB}}", "ai_pkgmanager$suffix")
 executeQuery master $createDatabaseQuery.Replace("{{DB}}", "ai_trainer$suffix")
+executeQuery master $createDatabaseQuery.Replace("{{DB}}", "ai_appmanager$suffix")
 
 
 #Execute Grants
@@ -171,3 +180,4 @@ executeQuery "ai_helper$suffix" $grantcommand
 executeQuery "ai_deployer$suffix" $grantcommand
 executeQuery "ai_pkgmanager$suffix" $grantcommand
 executeQuery "ai_trainer$suffix" $grantcommand
+executeQuery "ai_appmanager$suffix" $grantcommand

--- a/platform/aks/azuredeploy.sql.json
+++ b/platform/aks/azuredeploy.sql.json
@@ -1,0 +1,204 @@
+{
+    "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+    "contentVersion": "1.0.0.0",
+    "parameters": {
+        "serverName": {
+            "type": "string",
+            "defaultValue": "[uniqueString('sql', resourceGroup().id)]",
+            "metadata": {
+                "description": "The name of the SQL logical server."
+            }
+        },
+        "location": {
+            "type": "string",
+            "defaultValue": "[resourceGroup().location]",
+            "metadata": {
+                "description": "Location for all resources."
+            }
+        },
+        "administratorLogin": {
+            "type": "string",
+            "metadata": {
+                "description": "The administrator username of the SQL logical server."
+            }
+        },
+        "administratorLoginPassword": {
+            "type": "securestring",
+            "metadata": {
+                "description": "The administrator password of the SQL logical server."
+            }
+        },
+        "allowAzureIPs": {
+            "defaultValue": true,
+            "type": "bool",
+            "metadata": {
+                "description": "Allow Azure services to access server."
+            }
+        },
+        "connectionType": {
+            "defaultValue": "Default",
+            "allowedValues": [
+                "Default",
+                "Redirect",
+                "Proxy"
+            ],
+            "type": "string",
+            "metadata": {
+                "description": "SQL logical server connection type."
+            }
+        },
+        "sqlDatabaseTier": {
+            "defaultValue": "Standard",
+            "allowedValues": [
+                "Standard",
+                "Premium"
+            ],
+            "type": "string",
+            "metadata": {
+                "description": "SQL Database sku size."
+            }
+        },
+        "sqlDatabaseSize": {
+            "defaultValue": "S2",
+            "allowedValues": [
+                "S1",
+                "S2",
+                "S3"
+            ],
+            "type": "string",
+            "metadata": {
+                "description": "SQL Database sku size."
+            }
+        }
+    },
+    "resources": [
+        {
+            "type": "Microsoft.Sql/servers",
+            "apiVersion": "2018-06-01-preview",
+            "name": "[parameters('serverName')]",
+            "location": "[parameters('location')]",
+            "properties": {
+                "administratorLogin": "[parameters('administratorLogin')]",
+                "administratorLoginPassword": "[parameters('administratorLoginPassword')]",
+                "version": "12.0"
+            },
+            "resources": [
+                {
+                    "condition": "[parameters('allowAzureIPs')]",
+                    "type": "firewallRules",
+                    "apiVersion": "2018-06-01-preview",
+                    "name": "AllowAllWindowsAzureIps",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Sql/servers', parameters('serverName'))]"
+                    ],
+                    "properties": {
+                        "endIpAddress": "0.0.0.0",
+                        "startIpAddress": "0.0.0.0"
+                    }
+                },
+                {
+                    "type": "connectionPolicies",
+                    "apiVersion": "2014-04-01",
+                    "name": "Default",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Sql/servers', parameters('serverName'))]"
+                    ],
+                    "properties": {
+                        "connectionType": "[parameters('connectionType')]"
+                    }
+                },
+                {
+                    "type": "databases",
+                    "apiVersion": "2019-06-01-preview",
+                    "name": "ai_trainer",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Sql/servers', parameters('serverName'))]"
+                    ],
+                    "properties": {
+                        "edition": "Basic",
+                        "requestedServiceObjectiveName": "Basic",
+                        "collation": "SQL_Latin1_General_CP1_CI_AS"
+                    },
+                    "sku": {
+                        "name": "[parameters('sqlDatabaseSize')]",
+                        "tier": "[parameters('sqlDatabaseTier')]"
+                    }
+                },
+                {
+                    "type": "databases",
+                    "apiVersion": "2019-06-01-preview",
+                    "name": "ai_deployer",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Sql/servers', parameters('serverName'))]"
+                    ],
+                    "properties": {
+                        "edition": "Basic",
+                        "requestedServiceObjectiveName": "Basic",
+                        "collation": "SQL_Latin1_General_CP1_CI_AS"
+                    },
+                    "sku": {
+                        "name": "[parameters('sqlDatabaseSize')]",
+                        "tier": "[parameters('sqlDatabaseTier')]"
+                    }
+                },
+                {
+                    "type": "databases",
+                    "apiVersion": "2019-06-01-preview",
+                    "name": "ai_helper",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Sql/servers', parameters('serverName'))]"
+                    ],
+                    "properties": {
+                        "edition": "Basic",
+                        "requestedServiceObjectiveName": "Basic",
+                        "collation": "SQL_Latin1_General_CP1_CI_AS"
+                    },
+                    "sku": {
+                        "name": "[parameters('sqlDatabaseSize')]",
+                        "tier": "[parameters('sqlDatabaseTier')]"
+                    }
+                },
+                {
+                    "type": "databases",
+                    "apiVersion": "2019-06-01-preview",
+                    "name": "ai_pkgmanager",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Sql/servers', parameters('serverName'))]"
+                    ],
+                    "properties": {
+                        "edition": "Basic",
+                        "requestedServiceObjectiveName": "Basic",
+                        "collation": "SQL_Latin1_General_CP1_CI_AS"
+                    },
+                    "sku": {
+                        "name": "[parameters('sqlDatabaseSize')]",
+                        "tier": "[parameters('sqlDatabaseTier')]"
+                    }
+                },
+                {
+                    "type": "databases",
+                    "apiVersion": "2019-06-01-preview",
+                    "name": "ai_appmanager",
+                    "location": "[parameters('location')]",
+                    "dependsOn": [
+                        "[resourceId('Microsoft.Sql/servers', parameters('serverName'))]"
+                    ],
+                    "properties": {
+                        "edition": "Basic",
+                        "requestedServiceObjectiveName": "Basic",
+                        "collation": "SQL_Latin1_General_CP1_CI_AS"
+                    },
+                    "sku": {
+                        "name": "[parameters('sqlDatabaseSize')]",
+                        "tier": "[parameters('sqlDatabaseTier')]"
+                    }
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
* AIFBR-4473

DB Creation Script:
* Added an additional param named -dbpass through which user can provide his own password instead of using autogenerated one, the purpose of this is say for example 4 databases has been already created and a 5th one needs to be added, so you will just re-run the script with the old password and the script will create the missing DB with the old password
* Added ai_appmanager Database creation commands

Orchestrator Web Edit Script:
* AKS HA customers will be using domain name to access ai-app instead of hostName:port combo , so made the changes to the script accordingly 

AKS Arm DB Creation Template:
* ARM templates right now doesn't have any provision to link a template that is present on the local disk, to link the template should be downloadable via https or http , right now the dbcreation.json is getting downloaded from some storage account which is not present in our subscription, so instead of keeping the file in the storage account, I have moved the file here since this repo is a public , the risk of making a storage account public is what ever files we put there will also become public, so this is an better option than making a storage account public 