### PR TITLE
Storage Checks Before Triggering Onebox Installer

### DIFF
--- a/platform/onebox/aif-install-onebox.sh
+++ b/platform/onebox/aif-install-onebox.sh
@@ -18,3 +18,5 @@ execute ../scripts/os-check.sh
 execute ../scripts/storage-check.sh
 #Install Kubernetes
 execute ../scripts/install-kurl.sh
+#Create service account
+execute ../scripts/create-serviceaccount.sh

--- a/platform/onebox/aif-install-onebox.sh
+++ b/platform/onebox/aif-install-onebox.sh
@@ -11,10 +11,10 @@ execute() {
 }
 
 #Check if lvm is installed
-execute ./scripts/lvm-checks.sh
+execute ../scripts/lvm-checks.sh
 #OS Check
-execute ./scripts/os-check.sh
+execute ../scripts/os-check.sh
 #Check if RAW disks are available
-execute ./scripts/storage-check.sh
+execute ../scripts/storage-check.sh
 #Install Kubernetes
-execute ./scripts/install-curl.sh
+execute ../scripts/install-curl.sh

--- a/platform/onebox/aif-install-onebox.sh
+++ b/platform/onebox/aif-install-onebox.sh
@@ -11,7 +11,7 @@ execute() {
 }
 
 #Check if lvm is installed
-execute ../scripts/lvm-checks.sh
+execute ../scripts/lvm-check.sh
 #OS Check
 execute ../scripts/os-check.sh
 #Check if RAW disks are available

--- a/platform/onebox/aif-install-onebox.sh
+++ b/platform/onebox/aif-install-onebox.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# execute function
+execute() {
+  bash $1
+  if [ $? -ne 0 ];
+  then
+    echo "[ERROR]: Onebox installation failed. Exiting !!!"
+    exit 1
+  fi
+}
+
+#Check if lvm is installed
+execute ./scripts/lvm-checks.sh
+#OS Check
+execute ./scripts/os-check.sh
+#Check if RAW disks are available
+execute ./scripts/storage-check.sh
+#Install Kubernetes
+execute ./scripts/install-curl.sh

--- a/platform/onebox/aif-install-onebox.sh
+++ b/platform/onebox/aif-install-onebox.sh
@@ -17,4 +17,4 @@ execute ../scripts/os-check.sh
 #Check if RAW disks are available
 execute ../scripts/storage-check.sh
 #Install Kubernetes
-execute ../scripts/install-curl.sh
+execute ../scripts/install-kurl.sh

--- a/platform/scripts/create-serviceaccount.sh
+++ b/platform/scripts/create-serviceaccount.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Creating provision service account"
-bash -l
 chmod +r /etc/kubernetes/admin.conf
-kubectl create -n default serviceaccount provision 
+export KUBECONFIG=/etc/kubernetes/admin.conf
+kubectl create -n default serviceaccount provision
 kubectl create -n default clusterrolebinding provision-admin --clusterrole=cluster-admin --serviceaccount=default:provision

--- a/platform/scripts/create-serviceaccount.sh
+++ b/platform/scripts/create-serviceaccount.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+echo "Creating provision service account"
+bash -l
+chmod +r /etc/kubernetes/admin.conf
+kubectl create -n default serviceaccount provision 
+kubectl create -n default clusterrolebinding provision-admin --clusterrole=cluster-admin --serviceaccount=default:provision

--- a/platform/scripts/install-kurl.sh
+++ b/platform/scripts/install-kurl.sh
@@ -1,7 +1,3 @@
 #!/bin/bash
 
 curl -sSL https://k8s.kurl.sh/aif-core-oneboxinstaller | sudo bash
-bash -l
-chmod +r /etc/kubernetes/admin.conf
-kubectl create -n default serviceaccount provision 
-kubectl create -n default clusterrolebinding provision-admin --clusterrole=cluster-admin --serviceaccount=default:provision

--- a/platform/scripts/install-kurl.sh
+++ b/platform/scripts/install-kurl.sh
@@ -2,6 +2,6 @@
 
 curl -sSL https://k8s.kurl.sh/aif-core-oneboxinstaller | sudo bash
 bash -l
-sudo chmod +r /etc/kubernetes/admin.conf
+chmod +r /etc/kubernetes/admin.conf
 kubectl create -n default serviceaccount provision 
 kubectl create -n default clusterrolebinding provision-admin --clusterrole=cluster-admin --serviceaccount=default:provision

--- a/platform/scripts/install-kurl.sh
+++ b/platform/scripts/install-kurl.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+curl -sSL https://k8s.kurl.sh/aif-core-oneboxinstaller | sudo bash
+bash -l
+sudo chmod +r /etc/kubernetes/admin.conf
+kubectl create -n default serviceaccount provision 
+kubectl create -n default clusterrolebinding provision-admin --clusterrole=cluster-admin --serviceaccount=default:provision

--- a/platform/scripts/lvm-check.sh
+++ b/platform/scripts/lvm-check.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+echo "[INFO]: Starting LVM check.."
+
+LVM_VERSION=$( lvm version | grep "LVM version" )
+
+if [ "${LVM_VERSION}" != "" ];
+then
+  echo "[INFO]: LVM check - lvm is installed."
+else
+  echo "[ERROR]: lvm is not installed. Exiting.."
+  exit 1;
+fi

--- a/platform/scripts/os-check.sh
+++ b/platform/scripts/os-check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+echo "[INFO]: Starting OS validation.."
+
+if [ -f /etc/os-release ];
+then
+  . /etc/os-release
+  OS=$NAME
+  VER=$VERSION_ID
+
+elif [ -f /etc/lsb-release ];
+then
+  . /etc/lsb-release
+  OS=$DISTRIB_ID
+  VER=$DISTRIB_RELEASE
+else
+  # Fall back to uname, e.g. "Linux <version>", also works for BSD, etc.
+  OS=$(uname -s)
+  VER=$(uname -r)
+fi
+
+if [[ ("${OS}" != "Ubuntu") && ("${OS}" != "Red Hat Enterprise Linux Server") ]];
+then
+  echo "[ERROR]: OS check failed. Only Ubuntu and RHEL is supported. Exiting.. "
+  exit 1;
+fi
+
+MAJOR_VERSION=${VER%.*}
+
+if [[ ("${OS}" == "Ubuntu") && ($MAJOR_VERSION -lt "16") ]];
+then
+  echo "[ERROR]: Version check failed. Minimum version supported is 16.0. Exiting.."
+  exit 1;
+fi
+
+echo "[INFO]: OS validation completed"

--- a/platform/scripts/storage-check.sh
+++ b/platform/scripts/storage-check.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+  
+avail_device_count=0
+#Get all devices
+disks=$( lsblk --all --paths --nodeps --pairs --output NAME | grep -v -e "loop" -e "rbd" -e "ceph" )
+IFS=$'\n'
+set -o noglob  # or more tersely set -f
+
+#Loop through all devices
+for disk in $disks; do
+  DEVICE=$(echo "$disk" | cut -f2 -d= | tr -d '"')
+  FS_KEY_VAL=$(udevadm info --query=property "$DEVICE" | grep "ID_FS_TYPE")
+  FILE_SYSTEM=$(echo "$FS_KEY_VAL" | cut -f2 -d= | tr -d '"')
+  RO=$(lsblk $DEVICE --nodeps --noheadings --output RO)
+  DEVICE_TYPE=$(lsblk $DEVICE --nodeps --noheadings --output TYPE)
+  PARTITION_COUNT=$(lsblk $DEVICE --bytes --pairs --output NAME,SIZE,TYPE,PKNAME | grep "part" | wc -l)
+  #if partition_count is emtpy initialize it to zero
+  if [[ -z $PARTITION_COUNT ]];
+  then
+    PARTITION_COUNT=0
+  fi
+  PARENT_DEVICE=$(lsblk $DEVICE --nodeps --noheadings --paths --output PKNAME)
+  SIZE=$(lsblk $DEVICE --nodeps --noheadings --paths --output SIZE)
+
+  echo "Device attached to the Machine, Device: $DEVICE FileSystem: $FILE_SYSTEM RO: $RO DeviceType: $DEVICE_TYPE PartitionCount: $PARTITION_COUNT ParentDevice: $PARENT_DEVICE Size: $SIZE"
+
+  # if the device has file system associated with it, then ceph cant use the disk
+  if [[ ! -z $FILE_SYSTEM ]];
+  then
+    echo "Device: $DEVICE cant be used by ceph as it has an FileSystem: $FILE_SYSTEM associated with it"
+  fi
+
+  #If the Device has paritions then ceph cant use the device
+  if [[ $PARTITION_COUNT -gt 0 ]];
+  then
+    echo "Device: $DEVICE cant be used by ceph as it has Partitions: $PARTITION_COUNT associated with it"
+  fi
+
+  #remove the character G from size
+  SIZE=${SIZE::-1}
+
+  if [[ -z $PARENT_DEVICE && -z $FILE_SYSTEM && $PARTITION_COUNT -eq 0 && $RO -eq 0 ]]
+  then
+    if [[ "$DEVICE_TYPE" == "disk" || "$DEVICE_TYPE" == "ssd" || "$DEVICE_TYPE" == "crypt" || "$DEVICE_TYPE" = "lvm" ]];
+    then
+      echo "Available Device for CEPH Consumption is $DEVICE Size: $SIZE DeviceType: $DEVICE_TYPE"
+      avail_device_count=$((avail_device_count+1))
+
+      if [ $SIZE -lt 500 ];
+      then
+        echo "Device $DEVICE available for ceph consumption but its size $SIZE GB is less than recommended size i.e 500GB"
+      fi
+    fi
+  fi
+
+done
+
+if [ $avail_device_count -eq 0 ];
+then
+  echo "Sorry, There arent any devices available for CEPH consumption !!"
+  exit 1
+fi


### PR DESCRIPTION
* Storage Checks Before Triggering Onebox Installer 
* AIFBR-6039
* The approach that am taking here is, I have removed the deviceFilter all together from this config https://vendor.replicated.com/apps/aif-core/kurl/51 , ceph with bluestore enabled will by default skip the boot disk and the other disks which has file system associated with it ... so if the machine has any disks which ceph can leverage then installation would pass..... and to avoid the scenario of installation getting stuck due to non-availability of raw disks , i have written this storage-check.sh and wrapped kurl.sh into an other shell script