### PR TITLE
Update version number for 22.10 for CV 

### DIFF
--- a/metadata/ComputerVision__22100701__metadata.json
+++ b/metadata/ComputerVision__22100701__metadata.json
@@ -19,7 +19,7 @@
   "tenantName": "UiPath",
   "minAIFabricVersion": "22.10",
   "languageVersion": 3,
-  "version": 9,
+  "version": 22100701,
   "customVersion": "22.10.10",
   "imagePath": "cv2210:22.10.7.1",
   "parametersFileJSON":  "{\"probes\": [{\"probe\": \"startup\",\"initialDelaySeconds\": \"0\",\"periodSeconds\": \"1\",\"timeoutSeconds\": \"1\",\"successThreshold\": \"1\",\"failureThreshold\": \"200\"}]}"


### PR DESCRIPTION
Update the versioning schema also, in order to match with actual CV versioning schema and decreasing the chances of adding a wrong version number