### PR TITLE
Update the existing 24.10.3 doc ocr

### DIFF
--- a/metadata/UiPathDocumentOCR__31__metadata.json
+++ b/metadata/UiPathDocumentOCR__31__metadata.json
@@ -19,8 +19,8 @@
   "tenantName": "UiPath",
   "minAIFabricVersion": "22.10",
   "languageVersion": 4,
-  "version": 37,
-  "customVersion": "24.10.4",
-  "imagePath": "du-doc-ocr:v24.10-3.28-rc01",
+  "version": 31,
+  "customVersion": "24.10.2",
+  "imagePath": "du-doc-ocr:v24.10-1.27-rc02",
   "parametersFileJSON": "{\"params\": [],\"probes\": [{\"probe\": \"startup\",\"initialDelaySeconds\": \"30\",\"periodSeconds\": \"10\",\"timeoutSeconds\": \"5\",\"successThreshold\": \"1\",\"failureThreshold\": \"60\"},{\"probe\": \"readiness\",\"initialDelaySeconds\": \"30\",\"periodSeconds\": \"15\",\"timeoutSeconds\": \"45\",\"successThreshold\": \"1\",\"failureThreshold\": \"2\"},{\"probe\": \"liveness\",\"initialDelaySeconds\": \"30\",\"periodSeconds\": \"60\",\"timeoutSeconds\": \"45\",\"successThreshold\": \"1\",\"failureThreshold\": \"3\"}]}"
 }

--- a/metadata/UiPathDocumentOCR__34__metadata.json
+++ b/metadata/UiPathDocumentOCR__34__metadata.json
@@ -21,6 +21,6 @@
   "languageVersion": 4,
   "version": 34,
   "customVersion": "24.10.3",
-  "imagePath": "du-doc-ocr:v24.10-3.11-rc01",
+  "imagePath": "du-doc-ocr:v24.10-3.28-rc01",
   "parametersFileJSON": "{\"params\": [],\"probes\": [{\"probe\": \"startup\",\"initialDelaySeconds\": \"30\",\"periodSeconds\": \"10\",\"timeoutSeconds\": \"5\",\"successThreshold\": \"1\",\"failureThreshold\": \"60\"},{\"probe\": \"readiness\",\"initialDelaySeconds\": \"30\",\"periodSeconds\": \"15\",\"timeoutSeconds\": \"45\",\"successThreshold\": \"1\",\"failureThreshold\": \"2\"},{\"probe\": \"liveness\",\"initialDelaySeconds\": \"30\",\"periodSeconds\": \"60\",\"timeoutSeconds\": \"45\",\"successThreshold\": \"1\",\"failureThreshold\": \"3\"}]}"
 }


### PR DESCRIPTION
In  this PR: https://github.com/UiPath/ai-customer-scripts/pull/373
I have added a new version of doc ocr.
Instead, we should have update the existing 24.10