### PR TITLE
bump ltc & mltc version and update zip

### DIFF
--- a/metadata/LightTextClassification__8__metadata.json
+++ b/metadata/LightTextClassification__8__metadata.json
@@ -19,6 +19,6 @@
     "tenantName": "UiPath",
     "minAIFabricVersion": "v24.10",
     "version": 8,
-    "customVersion":  "25.9.0",
-    "contentUri": "https://<placeholder-url>/publicmodels/AIC/LightTextClassification/25.9.0/bow_text_classifier_package.zip"
+    "customVersion":  "25.12.0",
+    "contentUri": "https://<placeholder-url>/publicmodels/AIC/LightTextClassification/25.12.0/bow_text_classifier_package.zip"
 }

--- a/metadata/MultiLingualTextClassification__6__metadata.json
+++ b/metadata/MultiLingualTextClassification__6__metadata.json
@@ -19,6 +19,6 @@
     "tenantName": "UiPath",
     "minAIFabricVersion": "v24.10",
     "version": 6,
-    "customVersion":  "25.9.0",
-    "contentUri": "https://<placeholder-url>/publicmodels/AIC/MultiLingualTextClassification/25.9.0/bert_text_classifier_package.zip"
+    "customVersion":  "25.12.0",
+    "contentUri": "https://<placeholder-url>/publicmodels/AIC/MultiLingualTextClassification/25.12.0/bert_text_classifier_package.zip"
 }


### PR DESCRIPTION
The 25.9.0 model had an issue where predicts were failing because model_name was not supplied.  