### PR TITLE
docs: fix 27 typos in comments and console messages

### DIFF
--- a/platform/dockeree/aif-uninstall.sh
+++ b/platform/dockeree/aif-uninstall.sh
@@ -1,6 +1,6 @@
 echo "Starting AIFabric De-Provisioning... Please ignore some of the 'No Resources found' errors, as they are harmless."
 
-echo "Instlling Helm on the machine"
+echo "Installing Helm on the machine"
 curl -L https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash -s -- --version v3.1.3
 
 echo "Uninstalling AIFabric Services"
@@ -49,7 +49,7 @@ chmod +x ./bin/istioctl
 kubectl delete namespace istio-system
 
 # Kots-Admin Uninstall
-echo "Unistalling Kots-Admin from the Cluster"
+echo "Uninstalling Kots-Admin from the Cluster"
 kubectl delete ns aif-core
 
 # Ceph uninstall

--- a/platform/onebox/backup_and_restore/ceph/export.sh
+++ b/platform/onebox/backup_and_restore/ceph/export.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 : '
-This scipt will export all data stored in blob storage from target environments.
+This script will export all data stored in blob storage from target environments.
 # $1 - json file with credentials, change the script to work with own credential manager
 # $2 - path to export
 Script will generate folders like path/ceph/bucket1 path/ceph/bucket2 each containing data from 1 bucket
@@ -38,7 +38,7 @@ function validate_dependency() {
   fi
 }
 
-# Validate required modules exits in target setup
+# Validate required modules exist in target setup
 function validate_setup() {
   validate_dependency "aws s3" "aws --version"
   validate_dependency "jq" "jq --version"
@@ -72,7 +72,7 @@ function download_blob() {
   echo "$green $(date) Starting sync of object storage to local disk for bucket ${BUCKET_NAME} $default"
   mkdir -p ${FOLDER}${BUCKET_NAME}
   aws s3 --endpoint-url $AWS_ENDPOINT --no-verify-ssl sync s3://${BUCKET_NAME} ${FOLDER}${BUCKET_NAME} --delete
-  echo "$green $(date) Finsihed sync of object storage to local disk for bucket ${BUCKET_NAME} $default"
+  echo "$green $(date) Finished sync of object storage to local disk for bucket ${BUCKET_NAME} $default"
 }
 
 function download_blob_old() {
@@ -97,7 +97,7 @@ function download_blob_old() {
     # sync all
     aws s3 --endpoint-url $AWS_ENDPOINT --no-verify-ssl sync s3://${BUCKET_NAME}/${PREFIX} ${FOLDER}${BUCKET_NAME}/${PREFIX} --delete
   fi
-  echo "$green $(date) Finsihed sync of object storage to local disk for bucket ${BUCKET_NAME} and prefix ${PREFIX} $default"
+  echo "$green $(date) Finished sync of object storage to local disk for bucket ${BUCKET_NAME} and prefix ${PREFIX} $default"
 }
 
 function sync_buckets() {

--- a/platform/onebox/backup_and_restore/ceph/get-credentials.sh
+++ b/platform/onebox/backup_and_restore/ceph/get-credentials.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 : '
-This scipt will generate json file for creds to be used with import export
+This script will generate json file for creds to be used with import export
 Script will generate file storage-creds.json
 Run it from the VM running aifabric.
 Use it as it is [insecure] or transfer to some credsManager and then change backup/restore scripts to fetch from credsmanager instead of json file

--- a/platform/onebox/backup_and_restore/ceph/import.sh
+++ b/platform/onebox/backup_and_restore/ceph/import.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 : '
-This scipt will import all data stored at a path to blob storage in target environments.
+This script will import all data stored at a path to blob storage in target environments.
 # $1 - json file with credentials, change the script to work with own credential manager
 # $2 - path to import from
 Script will look for folders like path/ceph/bucket1 path/ceph/bucket2 each containing data from 1 bucket and create bucket and upload
@@ -60,7 +60,7 @@ function upload_blob() {
   # sync folder to bucket
   echo "$green $(date) Starting sync of object storage to local disk for bucket ${BUCKET_NAME} $default"
   aws s3 --endpoint-url ${AWS_ENDPOINT} --no-verify-ssl --only-show-errors sync ${FOLDER}${DIR_NAME}/ s3://${BUCKET_NAME}
-  echo "$green $(date) Finsihed sync of object storage to local disk for bucket ${BUCKET_NAME} $default"
+  echo "$green $(date) Finished sync of object storage to local disk for bucket ${BUCKET_NAME} $default"
 }
 
 function update_cors_policy() {
@@ -96,7 +96,7 @@ function validate_dependency() {
   fi
 }
 
-# Validate required modules exits in target setup
+# Validate required modules exist in target setup
 function validate_setup() {
   validate_dependency "aws s3" "aws --version"
   validate_dependency s3cmd "s3cmd --version"

--- a/platform/onebox/backup_and_restore/clusterResources/export.sh
+++ b/platform/onebox/backup_and_restore/clusterResources/export.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 : '
-This script will export user oriented cluster resources from one enviornmnet to another envrionment
+This script will export user oriented cluster resources from one environment to another environment
 [Script Version -> 21.4]'
 
 red=$(tput setaf 1)
@@ -23,7 +23,7 @@ function validate_dependency() {
   fi
 }
 
-# Validate required modules exits in target setup
+# Validate required modules exist in target setup
 function validate_setup() {
   validate_dependency velero "velero version"
   echo "$(date) Successfully validated required dependencies"

--- a/platform/onebox/backup_and_restore/clusterResources/import.sh
+++ b/platform/onebox/backup_and_restore/clusterResources/import.sh
@@ -9,7 +9,7 @@ green=$(tput setaf 2)
 yellow=$(tput setaf 3)
 default=$(tput sgr0)
 
-echo "$green $(date) Starting export of user namespaces and pipeline related cron jobs $default"
+echo "$green $(date) Starting import of user namespaces and pipeline related cron jobs $default"
 
 readonly CLUSTER_RESOURCES_EXPORT_FILE=$1
 readonly CORE_SERVICE_NAMESPACE=aifabric
@@ -34,7 +34,7 @@ function validate_file_path() {
   fi
 }
 
-# Validate required modules exits in target setup
+# Validate required modules exist in target setup
 function validate_setup() {
   validate_dependency velero "velero version"
   echo "$(date) Successfully validated required dependencies"
@@ -64,7 +64,7 @@ function restore_namespace() {
   # Restore namespaces
   velero restore create --from-backup $NAMESPACES_BACKUP_NAME
 
-  echo "$(date) Successfully restore all user namespaces from backup $NAMESPACES_BACKUP_NAME"
+  echo "$(date) Successfully restored all user namespaces from backup $NAMESPACES_BACKUP_NAME"
 }
 
 # Restore cronjobs
@@ -73,7 +73,7 @@ function restore_cronjobs() {
 
   # Restore namespaces
   velero restore create --from-backup $CRONJOBS_BACKUP_NAME
-  echo "$(date) Successfully restore all cronjob from backup $CRONJOBS_BACKUP_NAME"
+  echo "$(date) Successfully restored all cronjob from backup $CRONJOBS_BACKUP_NAME"
 }
 
 # Patch secrets in namespaces

--- a/platform/onebox/backup_and_restore/credentials/idputils.sh
+++ b/platform/onebox/backup_and_restore/credentials/idputils.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 : '
-This scipt provides methods to fetch access token and register and de-register clients from identity server
+This script provides methods to fetch access token and register and de-register clients from identity server
 The following arguments are to be set by calling script so that they are available to is.sh
 # $1 - identityServerEndPoint: End point where identity server is hosted
 # $2 - hostTenantName: Host Tenant name registered in identity server
@@ -17,7 +17,7 @@ default=$(tput sgr0)
 
 # Fetch admin token from identity server end point using host tenant
 function internal_fetch_identity_server_token_to_register_client() {
-  echo "$(date) Fetching identity server client registeration token"
+  echo "$(date) Fetching identity server client registration token"
 
   # Generate required endpoints
   readonly local antif=https://$IDENTITY_SERVER_ENDPOINT"/identity/api/antiforgery/generate"
@@ -45,7 +45,7 @@ function internal_fetch_identity_server_token_to_register_client() {
   # Authentication -> POST to $login_url with the token in header "X-CSRF-Token: $token".
   curl --silent --fail --show-error -k -H "X-XSRF-TOKEN: $token" -c $cookie_file_new -b $cookie_file_new -d "$dataLogin" --request POST "$login" -H "Content-Type: application/json"
 
-  # Fetch Acces token
+  # Fetch Access token
   CLIENT_INSTALLTION_TOKEN=$(curl --silent --fail --show-error -k -H "X-XSRF-TOKEN: $token" -b $cookie_file_new "$tokenUrl" -H "Content-Type: application/json")
 
   if [ -z "$CLIENT_INSTALLTION_TOKEN" ]; then
@@ -54,7 +54,7 @@ function internal_fetch_identity_server_token_to_register_client() {
   fi
 }
 
-# Fetch access token to call backens server
+# Fetch access token to call backend server
 function internal_fetch_identity_server_access_token() {
   echo "$(date) Getting access token for client $IS_AIFABRIC_CLIENT_NAME from $IDENTITY_SERVER_ENDPOINT"
 

--- a/platform/onebox/backup_and_restore/registry/export.sh
+++ b/platform/onebox/backup_and_restore/registry/export.sh
@@ -26,7 +26,7 @@ function validate_dependency() {
   fi
 }
 
-# Validate required modules exits in target setup
+# Validate required modules exist in target setup
 function validate_setup() {
   validate_dependency curl "curl --version"
   validate_dependency jq "jq --version"

--- a/platform/onebox/backup_and_restore/registry/get-credentials.sh
+++ b/platform/onebox/backup_and_restore/registry/get-credentials.sh
@@ -14,8 +14,8 @@ default=$(tput sgr0)
 
 readonly PRIVATE_IP=$1
 
-# Validate dependecny module
-# $1 - Name of the dependecny module
+# Validate dependency module
+# $1 - Name of the dependency module
 # $2 - Command to validate module
 function validate_dependency() {
   list=$($2)
@@ -25,7 +25,7 @@ function validate_dependency() {
   fi
 }
 
-# Validate required modules exits in target setup
+# Validate required modules exist in target setup
 function validate_setup() {
   validate_dependency kubectl "kubectl version"
   echo "$(date) Successfully validated required dependencies"

--- a/platform/onebox/backup_and_restore/registry/import.sh
+++ b/platform/onebox/backup_and_restore/registry/import.sh
@@ -14,8 +14,8 @@ default=$(tput sgr0)
 readonly REGISTRY_IMPORT_FILE=$1
 readonly IMPORT_PATH=$2/registry
 
-# Validate dependecny module
-# $1 - Name of the dependecny module
+# Validate dependency module
+# $1 - Name of the dependency module
 # $2 - Command to validate module
 function validate_dependency() {
   eval $2
@@ -26,7 +26,7 @@ function validate_dependency() {
   fi
 }
 
-# Validate required modules exits in target setup
+# Validate required modules exist in target setup
 function validate_setup() {
   validate_dependency curl "curl --version"
   validate_dependency jq "jq --version"


### PR DESCRIPTION
## Summary

Fix 27 spelling/grammar typos in shell-script comments and `echo` output across the `platform/` maintenance scripts. No functional changes -- every edit is inside a comment or a message string.

Per the README's Changeset Procedure this PR is branched from and targets `alpha`, with a `users/{user-name}/{feature-name}` branch name.

### Copy-paste / wrong-word fixes (worth a closer look)

- **platform/onebox/backup_and_restore/clusterResources/import.sh**: the startup banner in `import.sh` announced `Starting export of user namespaces ...`; changed `export` -> `import` to match the script's own header ("This script will import user triggered cluster resources").

### Spelling / grammar

- **platform/dockeree/aif-uninstall.sh**: `Instlling` -> `Installing`, `Unistalling` -> `Uninstalling`
- **platform/onebox/backup_and_restore/ceph/export.sh**: `scipt` -> `script`, `exits` -> `exist`, `Finsihed` -> `Finished` (2x)
- **platform/onebox/backup_and_restore/ceph/get-credentials.sh**: `scipt` -> `script`
- **platform/onebox/backup_and_restore/ceph/import.sh**: `scipt` -> `script`, `Finsihed` -> `Finished`, `exits` -> `exist`
- **platform/onebox/backup_and_restore/clusterResources/export.sh**: `enviornmnet`/`envrionment` -> `environment`, `exits` -> `exist`
- **platform/onebox/backup_and_restore/clusterResources/import.sh**: `exits` -> `exist`, `Successfully restore` -> `Successfully restored` (2x)
- **platform/onebox/backup_and_restore/credentials/idputils.sh**: `scipt` -> `script`, `registeration` -> `registration`, `Acces` -> `Access`, `backens` -> `backend`
- **platform/onebox/backup_and_restore/registry/export.sh**: `exits` -> `exist`
- **platform/onebox/backup_and_restore/registry/get-credentials.sh**: `dependecny` -> `dependency` (2x), `exits` -> `exist`
- **platform/onebox/backup_and_restore/registry/import.sh**: `dependecny` -> `dependency` (2x), `exits` -> `exist`

Notes:
- `ceph/export.sh` contains two identical `Finsihed sync ...` messages; both were fixed so the file is internally consistent.
- The misspelled shell variable `CLIENT_INSTALLTION_TOKEN` in `idputils.sh` was deliberately left alone -- renaming an identifier is out of scope for a typo PR.
- Both files with CRLF line endings (`clusterResources/import.sh`, `clusterResources/export.sh`) were edited byte-wise, so line endings are unchanged.